### PR TITLE
fix switchMedia: stop previous track before switch

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -175,6 +175,15 @@ function updateStream() {
 messages.on('switchMedia', switchMedia)
 
 async function switchMedia() {
+  state.stream?.getTracks().forEach((track) => {
+    if (typeof track.stop === 'function' && track.readyState !== 'ended') {
+      track.stop()
+      // Manually emit the event, some webview implement doesn't fire it
+      const trackStoppedEvt = new MediaStreamTrackEvent('ended', { track })
+      track.dispatchEvent(trackStoppedEvt)
+    }
+  })
+
   const audio = {
     ...defaultAudioConstraints,
   }


### PR DESCRIPTION
manually emit the event,  some webview implement (firefox, android...) doesn't fire track-ended event, most common error thrown as "Could not start video source"